### PR TITLE
Disabled artifact expiry in .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,8 @@ before_script:
 verify:
   stage: verify
   artifacts:
+    # Disabling artifact expiry is not supported yet, so make
+    expire_in: 100 year
     paths:
       - ./*
   script:


### PR DESCRIPTION
Make sure generated artifacts on the CI are not deleted after 30 days.