### PR TITLE
Fixed bad Issue-URL for idin issuer

### DIFF
--- a/pbdf/Issues/idin/description.xml
+++ b/pbdf/Issues/idin/description.xml
@@ -16,7 +16,7 @@
 	</Description>
 	<ShouldBeSingleton>true</ShouldBeSingleton>
 	<IssueURL>
-		<en>https://privacybydesign.foundation/issuance/idin/</en>
+		<en>https://privacybydesign.foundation/uitgifte/idin/</en>
 		<nl>https://privacybydesign.foundation/uitgifte/idin/</nl>
 	</IssueURL>
 


### PR DESCRIPTION
Changed to match url on privacybydesign.foundation/issuance for idin issuer.