### PR TITLE
remove sidn-pbdf.email issueURL

### DIFF
--- a/sidn-pbdf/Issues/email/description.xml
+++ b/sidn-pbdf/Issues/email/description.xml
@@ -16,8 +16,6 @@
 	</Description>
 	<ShouldBeSingleton>false</ShouldBeSingleton>
 	<IssueURL>
-		<en></en>
-		<nl></nl>
 	</IssueURL>
 
 	<ForegroundColor>#15222E</ForegroundColor>


### PR DESCRIPTION
Because of an non-empty issueURL an "add" button appears in the app.
If we want to notify verifiers to include this credential in their
CredentialRequest, it should not show this button in the app since
the issueURL is not reachable (yet).