### PR TITLE
fix app not displaying important part of sidn-pbdf issuer name 

### DIFF
--- a/sidn-pbdf/description.xml
+++ b/sidn-pbdf/description.xml
@@ -5,8 +5,8 @@
 		<nl>PbDF via SIDN</nl>
 	</ShortName>
 	<Name>
-		<en>Privacy by Design Foundation via SIDN</en>
-		<nl>Stichting Privacy by Design via SIDN</nl>
+		<en>SIDN on behalf of Privacy by Design Foundation</en>
+		<nl>SIDN namens Stichting Privacy by Design</nl>
 	</Name>
 	<SchemeManager>pbdf</SchemeManager>
 	<ContactAddress>https://www.sidn.nl</ContactAddress>


### PR DESCRIPTION
Due to its length, the import bit falls off in the app. For now this is a temporary (fast) resolution.
In the long run we do want to adjust the app to render these on two lines.