### PR TITLE
feat: deprecate pbdf.email on 30 nov 2020 00:00 UTC

### DIFF
--- a/pbdf/Issues/email/description.xml
+++ b/pbdf/Issues/email/description.xml
@@ -10,6 +10,7 @@
 	<SchemeManager>pbdf</SchemeManager>
 	<IssuerID>pbdf</IssuerID>
 	<CredentialID>email</CredentialID>
+	<DeprecatedSince>1606694400</DeprecatedSince>
 	<Description>
 		<en>Your verified email address</en>
 		<nl>Je geverifieerde e-mailadres</nl>

--- a/pbdf/Issues/email/description.xml
+++ b/pbdf/Issues/email/description.xml
@@ -16,15 +16,10 @@
 		<nl>Je geverifieerde e-mailadres</nl>
 	</Description>
 	<ShouldBeSingleton>false</ShouldBeSingleton>
-	<IssueURL>
-		<en>https://privacybydesign.foundation/issuance/email/</en>
-		<nl>https://privacybydesign.foundation/uitgifte/email/</nl>
-	</IssueURL>
 
 	<ForegroundColor>#15222E</ForegroundColor>
 	<BackgroundGradientStart>#3BB992</BackgroundGradientStart>
 	<BackgroundGradientEnd>#6CE6C1</BackgroundGradientEnd>
-	<IsInCredentialStore>true</IsInCredentialStore>
 	<Category>
 		<en>Personal</en>
 		<nl>Persoonlijk</nl>

--- a/sidn-pbdf/Issues/email/description.xml
+++ b/sidn-pbdf/Issues/email/description.xml
@@ -23,7 +23,7 @@
 	<ForegroundColor>#15222E</ForegroundColor>
 	<BackgroundGradientStart>#3BB992</BackgroundGradientStart>
 	<BackgroundGradientEnd>#6CE6C1</BackgroundGradientEnd>
-	<IsInCredentialStore>false</IsInCredentialStore>
+	<IsInCredentialStore>true</IsInCredentialStore>
 	<Category>
 		<en>Personal</en>
 		<nl>Persoonlijk</nl>


### PR DESCRIPTION
~We could merge this in advance and we wont have to wait 3 hours before taking down our issuer on nov 30.~
This MR
- sets `pbdf.email` to deprecated,
- switches the credentials in our store in `irmamobile`,
- removes the `IssueURL` from the old credential.

We should merge this on 30 nov 2020 (otherwise a deprecated credential ends up in our store).