### PR TITLE
removed the word 'DigiD' from the labels

### DIFF
--- a/gemeente/Issues/personalData/description.xml
+++ b/gemeente/Issues/personalData/description.xml
@@ -218,12 +218,12 @@
 		</Attribute>
 		<Attribute id="digidlevel" displayIndex="17">
 			<Name>
-				<en>DigiD assurance level</en>
-				<nl>DigiD betrouwbaarheidsniveau</nl>
+				<en>Assurance level</en>
+				<nl>Betrouwbaarheidsniveau</nl>
 			</Name>
 			<Description>
-				<en>The DigiD assurance level with which your identity was verified</en>
-				<nl>Het DigiD betrouwbaarheidsniveau waarmee je identiteit is vastgesteld</nl>
+				<en>The assurance level with which your identity was verified</en>
+				<nl>Het betrouwbaarheidsniveau waarmee je identiteit is vastgesteld</nl>
 			</Description>
 		</Attribute>
 	</Attributes>


### PR DESCRIPTION
of the 'digidlevel' attribute
scheme isn't signed yet.