### PR TITLE
Update and deprecate PbdF credentials

### DIFF
--- a/pbdf/Issues/ageLimits/description.xml
+++ b/pbdf/Issues/ageLimits/description.xml
@@ -16,8 +16,8 @@
 	</Description>
 	<ShouldBeSingleton>true</ShouldBeSingleton>
 	<IssueURL>
-		<en>https://privacybydesign.foundation/uitgifte/idin/</en>
-		<nl>https://privacybydesign.foundation/uitgifte/idin/</nl>
+		<en>https://idin-issuer.yivi.app/</en>
+		<nl>https://idin-issuer.yivi.app/</nl>
 	</IssueURL>
 
 	<ForegroundColor>#ffffff</ForegroundColor>

--- a/pbdf/Issues/diploma/description.xml
+++ b/pbdf/Issues/diploma/description.xml
@@ -10,6 +10,7 @@
 	<SchemeManager>pbdf</SchemeManager>
 	<IssuerID>pbdf</IssuerID>
 	<CredentialID>diploma</CredentialID>
+	<DeprecatedSince>1744970400</DeprecatedSince>
 	<Description>
 		<en>Data extracted from your diploma provided by DUO</en>
 		<nl>Gegevens uit je diploma, verkregen via DUO</nl>

--- a/pbdf/Issues/irmatube/description.xml
+++ b/pbdf/Issues/irmatube/description.xml
@@ -10,6 +10,7 @@
 	<SchemeManager>pbdf</SchemeManager>
 	<IssuerID>pbdf</IssuerID>
 	<CredentialID>irmatube</CredentialID>
+	<DeprecatedSince>1744970400</DeprecatedSince>
 	<Description>
 		<en>Your IRMATube membership attributes</en>
 		<nl>Je IRMATube lidmaatschapsattributen</nl>

--- a/pbdf/Issues/linkedin/description.xml
+++ b/pbdf/Issues/linkedin/description.xml
@@ -16,8 +16,8 @@
 	</Description>
 	<ShouldBeSingleton>false</ShouldBeSingleton>
 	<IssueURL>
-		<en>https://privacybydesign.foundation/issuance/social/linkedin/</en>
-		<nl>https://privacybydesign.foundation/uitgifte/social/linkedin/</nl>
+		<en>https://saml-issuer.yivi.app/en/linkedin/</en>
+		<nl>https://saml-issuer.yivi.app/nl/linkedin/</nl>
 	</IssueURL>
 
 	<ForegroundColor>#FFFFFF</ForegroundColor>

--- a/pbdf/Issues/surfnet-2/description.xml
+++ b/pbdf/Issues/surfnet-2/description.xml
@@ -16,8 +16,8 @@
 	</Description>
 	<ShouldBeSingleton>false</ShouldBeSingleton>
 	<IssueURL>
-		<en>https://privacybydesign.foundation/issuance/surfconext/surfconext/</en>
-		<nl>https://privacybydesign.foundation/uitgifte/surfconext/surfconext/</nl>
+		<en>https://saml-issuer.yivi.app/en/surfconext/</en>
+		<nl>https://saml-issuer.yivi.app/nl/surfconext/</nl>
 	</IssueURL>
 
 	<ForegroundColor>#15222E</ForegroundColor>

--- a/pbdf/Issues/surfnet/description.xml
+++ b/pbdf/Issues/surfnet/description.xml
@@ -10,6 +10,7 @@
 	<SchemeManager>pbdf</SchemeManager>
 	<IssuerID>pbdf</IssuerID>
 	<CredentialID>surfnet</CredentialID>
+	<DeprecatedSince>1744970400</DeprecatedSince>
 	<Description>
 		<en>Your Surfnet attributes obtained through SURFconext</en>
 		<nl>Je Surfnet-attributen, verkregen via SURFconext</nl>

--- a/pbdf/Issues/twitter/description.xml
+++ b/pbdf/Issues/twitter/description.xml
@@ -10,6 +10,7 @@
 	<SchemeManager>pbdf</SchemeManager>
 	<IssuerID>pbdf</IssuerID>
 	<CredentialID>twitter</CredentialID>
+	<DeprecatedSince>1744970400</DeprecatedSince>
 	<Description>
 		<en>Twitter attributes from your Twitter account</en>
 		<nl>Twitter attributen uit je Twitter account</nl>


### PR DESCRIPTION
In consultation with @bajacobs, we deprecate some credentials and point URLs to `privacybydesign.foundation` to the new `yivi.app` domain.

### URL Updates:
* Updated the URLs in `pbdf/Issues/ageLimits/description.xml` to point to the new `yivi.app` domain.
* Updated the URLs in `pbdf/Issues/linkedin/description.xml` to point to the new `yivi.app` domain.
* Updated the URLs in `pbdf/Issues/surfnet-2/description.xml` to point to the new `yivi.app` domain.

### Deprecation Tags:
* Added the `DeprecatedSince` tag to `pbdf/Issues/diploma/description.xml`.
* Added the `DeprecatedSince` tag to `pbdf/Issues/irmatube/description.xml`.
* Added the `DeprecatedSince` tag to `pbdf/Issues/surfnet/description.xml`.
* Added the `DeprecatedSince` tag to `pbdf/Issues/twitter/description.xml`.