### PR TITLE
Remove DeprecatedSince from description.xml

### DIFF
--- a/PubHubs/description.xml
+++ b/PubHubs/description.xml
@@ -1,6 +1,5 @@
 <Issuer version="4">
   <ID>PubHubs</ID>
-  <DeprecatedSince>1775028603</DeprecatedSince>
   <Name>
 	  <en>PubHubs</en>
 	  <nl>PubHubs</nl>


### PR DESCRIPTION
Removed DeprecatedSince element from description.xml, since we have added a new public key.